### PR TITLE
관계적합도를 1회만 자동으로 띄워주게 변경했습니다

### DIFF
--- a/components/template/ResTemplate.tsx
+++ b/components/template/ResTemplate.tsx
@@ -52,10 +52,11 @@ function ResTemplate({ imgRef, relation, ...components }: ResTemplateProps) {
     router.push({ query: state ? { modal: true } : {} });
 
   useEffect(() => {
-    if (relation) {
+    if (relation && !sessionStorage.getItem('opened')) {
       setTimeout(() => {
         setRelationModalOpened(true);
       }, 500);
+      sessionStorage.setItem('opened', 'true');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,20 +7,20 @@ import HomeTopBar from '../components/organism/HomeTopBar';
 import HomeDescriptText from '../components/organism/HomeDescriptText';
 import HomeStepBox from '../components/organism/HomeStepBox';
 import { useRouter } from 'next/router';
-import { useShareParamState } from '../utils/state';
 import LayoutTemplate from '../components/template/LayoutTemplate';
 
 export default function Home() {
   const router = useRouter();
 
-  const { setData, ilju } = useShareParamState();
   useEffect(() => {
     if ('ilju' in router.query && 'username' in router.query) {
-      console.log(router.query);
-      setData({
-        ilju: parseInt(router.query.ilju as string),
-        username: router.query.username as string,
-      });
+      sessionStorage.setItem(
+        'shared-ilju',
+        JSON.stringify({
+          ilju: router.query.ilju,
+          username: router.query.username,
+        })
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query]);

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -15,21 +15,32 @@ import ResTemplate, {
   ResTemplateProps,
 } from '../components/template/ResTemplate';
 import { ResultParams } from '../components/types/StepInput';
-import { useShareParamState, useUserResultState } from '../utils/state';
+import { useUserResultState } from '../utils/state';
+
+export interface ShareParamData {
+  ilju: number | undefined;
+  username: string | undefined;
+}
 
 function Result() {
   const router = useRouter();
   const { userData, setError, error } = useUserResultState();
-  const { ilju, username } = useShareParamState();
+  // const { ilju, username } = useShareParamState();
   const ref = useRef<HTMLDivElement>(null);
 
   const [params, setParams] = useState<ResultParams>();
+  const [shareParam, setShareParam] = useState<ShareParamData>();
 
   const resultMutate = useMutation('get-result', getResult, {
     onError: () => setError(),
   });
 
   useEffect(() => {
+    if (sessionStorage.getItem('shared-ilju')) {
+      setShareParam(
+        JSON.parse(sessionStorage.getItem('shared-ilju') as string)
+      );
+    }
     if (userData) {
       setParams({
         gender: userData.gender || '',
@@ -48,10 +59,10 @@ function Result() {
   }, [userData]);
 
   useEffect(() => {
-    if (params) resultMutate.mutate({ ...params, target: ilju });
+    if (params) resultMutate.mutate({ ...params, target: shareParam?.ilju });
   }, [params]);
 
-  console.log(ilju, username);
+  console.log(shareParam);
 
   const resTemplateProps: Omit<ResTemplateProps, 'hasRelation'> = {
     descriptionTextComponent: (
@@ -77,8 +88,8 @@ function Result() {
     relationModalComponent: (
       <RelationView
         result={resultMutate.data}
-        targetIlju={ilju}
-        targetName={username}
+        targetIlju={shareParam?.ilju}
+        targetName={shareParam?.username}
         userData={userData}
       />
     ),
@@ -88,7 +99,7 @@ function Result() {
   return (
     <>
       {resultMutate.data ? (
-        <ResTemplate {...resTemplateProps} relation={username} />
+        <ResTemplate {...resTemplateProps} relation={shareParam?.username} />
       ) : resultMutate.isError ? (
         <ErrorTemplate />
       ) : (

--- a/utils/state.ts
+++ b/utils/state.ts
@@ -26,24 +26,3 @@ export const useUserResultState = create<UserResultState>()(
     )
   )
 );
-
-export interface ShareParamData {
-  ilju: number | undefined;
-  username: string | undefined;
-}
-interface ShareParamState extends ShareParamData {
-  setData: (data: ShareParamData) => void;
-  removeData: () => void;
-}
-
-export const useShareParamState = create<ShareParamState>()(
-  devtools(
-    (set) => ({
-      ilju: undefined,
-      username: undefined,
-      setData: (data) => set(() => ({ ...data })),
-      removeData: () => set(() => ({ ilju: undefined, username: undefined })),
-    }),
-    { name: 'share-param-store' }
-  )
-);


### PR DESCRIPTION
## 개요
공유하기를 통해 결과를 볼 때 처음 들어왔을때 뜬 이후, 다시 들어오면 더이상 자동으로 뜨지 않았으면 합니다.

## 작업내용
- 기존 zustand에 저장해놓았던 공유 유저의 state를 sessionStorage로 변경했습니다
- sessionStorage에 opened state를 추가해 1회 open 이후, 자동으로 열리지 않습니다

## 주의사항
